### PR TITLE
Fix for messages without "From" field

### DIFF
--- a/imap_inbox_check.py
+++ b/imap_inbox_check.py
@@ -25,7 +25,7 @@ def message_info_from_tuple(unread_indices, m):
         'unread': message_index_re.search(m[0]).group(1) in unread_indices,
         'date': parsed['Date'],
         'subject': parsed.get('Subject', ''),
-        'from': parsed['From'],
+        'from': parsed.get('From', ''),
     }
 
 def parse_date_from_message_dict(info):


### PR DESCRIPTION
I had a message in my inbox without the "From" field set. Instead of throwing an exception, get a default value of empty string.
